### PR TITLE
Fix PlacesResourcesMediaEvents creation when doing a BulkMediaUpload

### DIFF
--- a/TEKDB/TEKDB/admin.py
+++ b/TEKDB/TEKDB/admin.py
@@ -456,7 +456,7 @@ class MediaBulkUploadAdmin(admin.ModelAdmin):
         resources = form.cleaned_data.get('resources')
         citations = form.cleaned_data.get('citations')
         activities = form.cleaned_data.get('activities')
-        placeresources = form.cleaned_data.get('placeresources')
+        placesresources = form.cleaned_data.get('placesresources')
         
         for file in request.FILES.getlist('files'):
             mime_type, _ = guess_type(file.name)
@@ -493,9 +493,9 @@ class MediaBulkUploadAdmin(admin.ModelAdmin):
             if activities:
                 for activity in activities:
                     ResourceActivityMediaEvents.objects.create(resourceactivityid=activity, mediaid=media_instance)
-            if placeresources:
-                for placeresource in placeresources:
-                    PlaceResourceMediaEvents.objects.create(placeresourceid=placeresource, mediaid=media_instance)
+            if placesresources:
+                for placeresource in placesresources:
+                    PlacesResourceMediaEvents.objects.create(placeresourceid=placeresource, mediaid=media_instance)
 
 
     @admin.display(
@@ -579,7 +579,7 @@ class MediaBulkUploadAdmin(admin.ModelAdmin):
     'enteredbyname', 'enteredbytribe','enteredbytitle','enteredbydate')
     fieldsets = (
         (None, {
-            'fields': ('mediabulkname', 'mediabulkdescription', 'files', 'mediabulkdate', 'places', 'resources', 'citations', 'activities', 'placeresources', 'thumbnail_gallery')
+            'fields': ('mediabulkname', 'mediabulkdescription', 'files', 'mediabulkdate', 'places', 'resources', 'citations', 'activities', 'placesresources', 'thumbnail_gallery')
         }),
         ('History', {
             'fields': (

--- a/TEKDB/TEKDB/forms.py
+++ b/TEKDB/TEKDB/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.admin.widgets import FilteredSelectMultiple
-from .models import MediaBulkUpload, Media, Places, Resources, Citations, ResourcesActivityEvents, PlacesResourceMediaEvents
+from .models import MediaBulkUpload, Media, Places, Resources, Citations, ResourcesActivityEvents, PlacesResourceEvents
 from .widgets import ThumbnailFileInput
 
 
@@ -39,13 +39,13 @@ class MediaBulkUploadForm(forms.ModelForm):
         required=False,
         widget=FilteredSelectMultiple("Activities", is_stacked=False)
     )
-    placeresources = forms.ModelMultipleChoiceField(
-        queryset=PlacesResourceMediaEvents.objects.all(), 
+    placesresources = forms.ModelMultipleChoiceField(
+        queryset=PlacesResourceEvents.objects.all(), 
         required=False,
-        widget=FilteredSelectMultiple("Place Resources", is_stacked=False)
+        widget=FilteredSelectMultiple("Places Resources", is_stacked=False)
     )
 
     class Meta:
         model = MediaBulkUpload
-        fields = ['mediabulkname', 'mediabulkdescription', 'mediabulkdate', 'files', 'places', 'resources', 'citations', 'activities', 'placeresources']
+        fields = ['mediabulkname', 'mediabulkdescription', 'mediabulkdate', 'files', 'places', 'resources', 'citations', 'activities', 'placesresources']
     


### PR DESCRIPTION
This pull request makes updates to the `TEKDB` codebase to fix naming inconsistencies and align with the correct model and field names. The changes primarily involve renaming `placeresources` to `placesresources` and updating related references in the code.

### Updates to naming and model references:

* In `TEKDB/TEKDB/admin.py`:
  - Renamed `placeresources` to `placesresources` in the `save_model` method and updated the associated model from `PlaceResourceMediaEvents` to `PlacesResourceMediaEvents`. [[1]](diffhunk://#diff-3add7f2992b36a6130ba35d5aa078863cfb606a6fe14bcbc84cd6820b01cf272L459-R459) [[2]](diffhunk://#diff-3add7f2992b36a6130ba35d5aa078863cfb606a6fe14bcbc84cd6820b01cf272L496-R498)
  - Updated the `fieldsets` definition to use `placesresources` instead of `placeresources`.

* In `TEKDB/TEKDB/forms.py`:
  - Updated the import statement to replace `PlacesResourceMediaEvents` with `PlacesResourceEvents`.
  - Renamed the `placeresources` field to `placesresources` in the `MediaBulkUploadForm` class and updated its queryset and widget label accordingly.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210267165998087