### PR TITLE
add django-ckeditor to requirements.txt

### DIFF
--- a/TEKDB/requirements.txt
+++ b/TEKDB/requirements.txt
@@ -3,6 +3,7 @@ confusable-homoglyphs
 coverage
 django >=4.2.16,<4.3
 django-autocomplete-light
+django-ckeditor
 django-colorfield
 django-leaflet
 django-nested-admin


### PR DESCRIPTION
When running `python /usr/local/apps/TEKDB/TEKDB/manage.py migrate`, I recieved the error, `ModuleNotFoundError: No module named 'ckeditor’` .  These [docs](https://django-ckeditor.readthedocs.io/en/latest/#installation) helped me understand what package to install. 