### PR TITLE
proof of concept for setting version number env variable

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -1,0 +1,22 @@
+name: Build Docker Image on Release
+
+on:
+  push
+
+# on:
+#   release:
+#     types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set version
+        run: echo "APP_VERSION=${GITHUB_REF_NAME#v}" >> .env
+
+    #   - name: Build images
+    #     run: docker compose build --build-arg APP_VERSION=${GITHUB_REF_NAME#v}

--- a/TEKDB/TEKDB/settings.py
+++ b/TEKDB/TEKDB/settings.py
@@ -237,7 +237,7 @@ TINYMCE_EXTRA_MEDIA = False
 TINYMCE_FILEBROWSER = False
 
 # Add Version to the admin site header
-VERSION = "2.2.2"
+VERSION = os.getenv("APP_VERSION", "unknown")
 ADMIN_SITE_HEADER = os.environ.get(
     "ADMIN_SITE_HEADER", default="ITK DB Admin v{}".format(VERSION)
 )

--- a/TEKDB/docker-compose.yml
+++ b/TEKDB/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        APP_VERSION: ${APP_VERSION}
     restart: unless-stopped
     depends_on:
       - db
@@ -35,6 +37,7 @@ services:
       SQL_PASSWORD: postgrespw
       SECRET_KEY: 'change-me'
       DEBUG: '0'
+      APP_VERSION: ${APP_VERSION}
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
proof of concept on triggering a docker image build on release, using the release number as a build arg, and using the arg as an env variable to display in the admin site. 