### PR TITLE
Docker gis user

### DIFF
--- a/TEKDB/.env.dev
+++ b/TEKDB/.env.dev
@@ -7,3 +7,4 @@ SQL_USER=postgres
 SQL_PASSWORD=tekdb_password
 SQL_HOST=db
 SQL_PORT=5432
+GIS_USER_PASSWORD=foobar

--- a/TEKDB/.env.dev
+++ b/TEKDB/.env.dev
@@ -7,5 +7,5 @@ SQL_USER=postgres
 SQL_PASSWORD=tekdb_password
 SQL_HOST=db
 SQL_PORT=5432
-GIS_USER_PASSWORD=foobar
+GIS_USER_PASSWORD=gis_password
 CELERY_BROKER_URL=redis://redis:6379/0

--- a/TEKDB/entrypoint.sh
+++ b/TEKDB/entrypoint.sh
@@ -25,6 +25,36 @@ echo "Checking for existing users..."
 if [ "$(python manage.py shell -c 'from django.contrib.auth import get_user_model; print(get_user_model().objects.count())')" = "0" ]; then
     python manage.py loaddata TEKDB/fixtures/default_users_fixture.json
 fi
+
+# Set up restricted gis user after migrations now that tables are created
+echo "Configuring gis database permissions..."
+PGPASSWORD="$SQL_PASSWORD" psql -h "$SQL_HOST" -p "${SQL_PORT:-5432}" -U "$SQL_USER" -d "$SQL_DATABASE" <<EOF
+-- Create user if it doesn't already exist
+DO \$\$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'gis') THEN
+        CREATE USER gis WITH PASSWORD '${GIS_USER_PASSWORD}';
+        RAISE NOTICE 'Created gis user';
+    ELSE
+        RAISE NOTICE 'gis user already exists, skipping creation';
+    END IF;
+END;
+\$\$;
+
+-- Schema and table permissions
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+GRANT USAGE ON SCHEMA public TO gis;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE
+    public.places, 
+    public.lookuphabitat, 
+    public.lookupplanningunit, 
+    public.lookuptribe
+TO gis;
+GRANT USAGE, UPDATE ON SEQUENCE public.places_placeid_seq TO gis;
+EOF
+echo "gis user permissions configured."
+
+
 # Load default lookups only if no lookups exist. Use LookupPlanningUnit as the check.
 echo "Checking for existing lookups..."
 if [ "$(python manage.py shell -c 'from TEKDB.models import LookupPlanningUnit; print(LookupPlanningUnit.objects.count())')" = "0" ]; then

--- a/TEKDB/entrypoint.sh
+++ b/TEKDB/entrypoint.sh
@@ -29,7 +29,7 @@ fi
 
 # Set up restricted gis user after migrations now that tables are created
 echo "Configuring gis database permissions..."
-PGPASSWORD="$SQL_PASSWORD" psql -h "$SQL_HOST" -p "${SQL_PORT:-5432}" -U "$SQL_USER" -d "$SQL_DATABASE" <<EOF
+PGPASSWORD="$SQL_PASSWORD" psql -h "$SQL_HOST" -p "${SQL_PORT:-5432}" -U "$SQL_USER" -d "$SQL_DATABASE" -v ON_ERROR_STOP=1 <<EOF
 -- Create user if it doesn't already exist
 DO \$\$
 BEGIN
@@ -43,7 +43,6 @@ END;
 \$\$;
 
 -- Schema and table permissions
-REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 GRANT USAGE ON SCHEMA public TO gis;
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE
     public.places, 

--- a/docker/.env.dev
+++ b/docker/.env.dev
@@ -7,3 +7,4 @@ SQL_USER=postgres
 SQL_PASSWORD=tekdb_password
 SQL_HOST=db
 SQL_PORT=5432
+GIS_USER_PASSWORD=foobar

--- a/docker/.env.dev
+++ b/docker/.env.dev
@@ -7,4 +7,4 @@ SQL_USER=postgres
 SQL_PASSWORD=tekdb_password
 SQL_HOST=db
 SQL_PORT=5432
-GIS_USER_PASSWORD=foobar
+GIS_USER_PASSWORD=gis_password

--- a/docker/common.yaml
+++ b/docker/common.yaml
@@ -7,6 +7,7 @@ services:
       POSTGRES_DB: ${SQL_DATABASE}
       POSTGRES_USER: ${SQL_USER}
       POSTGRES_PASSWORD: ${SQL_PASSWORD}
+      GIS_USER_PASSWORD: ${GIS_USER_PASSWORD}
     volumes:
       - tekdb_db_data:/var/lib/postgresql/data
     ports:

--- a/docker/common.yaml
+++ b/docker/common.yaml
@@ -25,7 +25,8 @@ services:
       dockerfile: ../TEKDB/Dockerfile
     restart: unless-stopped
     env_file:
-      - .env.dev
+      - path: .env.dev
+        required: true
     ports:
       - "8000:8000"
 

--- a/docker/docker-compose.prod.local.yaml
+++ b/docker/docker-compose.prod.local.yaml
@@ -10,7 +10,8 @@ services:
       service: web
     command: ["prod-local"]
     env_file:
-      - .env.dev
+      - path: .env.dev
+        required: true
     ports: []
     depends_on:
       db:

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -11,7 +11,9 @@ services:
     image: ${ITKDB_ECR_PATH}:latest
     command: ["prod"]
     env_file:
-      - .env.prod
+      - path: .env.prod
+        required: true
+
     ports: []
     depends_on:
       db:
@@ -41,7 +43,8 @@ services:
       service: celery
     image: ${ITKDB_ECR_PATH}:latest
     env_file:
-      - .env.prod
+      - path: .env.prod
+        required: true
     volumes:
       - media_volume:/usr/src/app/media
   celery-beat:
@@ -50,7 +53,8 @@ services:
       service: celery-beat
     image: ${ITKDB_ECR_PATH}:latest
     env_file:
-      - .env.prod
+      - path: .env.prod
+        required: true
     volumes:
       - media_volume:/usr/src/app/media
 


### PR DESCRIPTION
[asana task](https://app.asana.com/1/5541737610303/project/1212860200263868/task/1213887042075368?focus=true)

Creates a 'gis' user in the Postgres database with permissions to read and write to tables with spatial or related data.

We need to do this in the entrypoint rather than a script to mount in the postgres container because we do not have the specific tables when the database container is spun up. The tables spin up when the django migrations run, so we create the 'gis' user with permissions after that process. 