### PR TITLE
Import and export warnings

### DIFF
--- a/TEKDB/TEKDB/tasks.py
+++ b/TEKDB/TEKDB/tasks.py
@@ -2,18 +2,12 @@ import os
 import logging
 from datetime import timedelta
 from celery import shared_task
-
 from django.utils import timezone
 
+from TEKDB.utils import bytes_to_readable
+
+
 logger = logging.getLogger("delete_expired_chunks")
-
-
-def bytes_to_readable(num_bytes, suffix="B"):
-    """Converts bytes to a human-readable format (e.g., KB, MB, GB)."""
-    for unit in ["", "K", "M", "G", "T", "P"]:
-        if num_bytes < 1024:
-            return f"{num_bytes:.2f} {unit}{suffix}"
-        num_bytes /= 1024
 
 
 @shared_task(bind=True, max_retries=3, autoretry_for=(Exception,))

--- a/TEKDB/TEKDB/tests/test_utils.py
+++ b/TEKDB/TEKDB/tests/test_utils.py
@@ -1,0 +1,77 @@
+from django.test import TestCase
+from unittest.mock import patch
+import shutil
+
+from TEKDB.utils import bytes_to_readable, check_disk_space
+
+
+class TestBytesToReadable(TestCase):
+    def test_bytes(self):
+        self.assertEqual(bytes_to_readable(512), "512.00 B")
+
+    def test_kilobytes(self):
+        self.assertEqual(bytes_to_readable(1024), "1.00 KB")
+        self.assertEqual(bytes_to_readable(2048), "2.00 KB")
+
+    def test_megabytes(self):
+        self.assertEqual(bytes_to_readable(1024 * 1024), "1.00 MB")
+        self.assertEqual(bytes_to_readable(5.5 * 1024 * 1024), "5.50 MB")
+
+    def test_gigabytes(self):
+        self.assertEqual(bytes_to_readable(1024 * 1024 * 1024), "1.00 GB")
+
+    def test_terabytes(self):
+        self.assertEqual(bytes_to_readable(1024 * 1024 * 1024 * 1024), "1.00 TB")
+
+    def test_petabytes(self):
+        self.assertEqual(bytes_to_readable(1024 * 1024 * 1024 * 1024 * 1024), "1.00 PB")
+
+    def test_zero_bytes(self):
+        self.assertEqual(bytes_to_readable(0), "0.00 B")
+
+    def test_custom_suffix(self):
+        self.assertEqual(bytes_to_readable(512, suffix="iB"), "512.00 iB")
+        self.assertEqual(bytes_to_readable(1024, suffix="iB"), "1.00 KiB")
+
+
+class TestCheckDiskSpace(TestCase):
+    def test_sufficient_space(self):
+        with patch("shutil.disk_usage") as mock_disk_usage:
+            mock_disk_usage.return_value = shutil._ntuple_diskusage(
+                free=1024 * 1024 * 1024,
+                total=10 * 1024 * 1024 * 1024,
+                used=9 * 1024 * 1024 * 1024,
+            )
+            has_space, free_bytes = check_disk_space(512 * 1024 * 1024)
+            self.assertTrue(has_space)
+            self.assertEqual(free_bytes, 1024 * 1024 * 1024)
+
+    def test_insufficient_space(self):
+        with patch("shutil.disk_usage") as mock_disk_usage:
+            mock_disk_usage.return_value = shutil._ntuple_diskusage(
+                free=256 * 1024 * 1024,
+                total=10 * 1024 * 1024 * 1024,
+                used=9 * 1024 * 1024 * 1024,
+            )
+            has_space, free_bytes = check_disk_space(512 * 1024 * 1024)
+            self.assertFalse(has_space)
+            self.assertEqual(free_bytes, 256 * 1024 * 1024)
+
+    def test_exact_space(self):
+        with patch("shutil.disk_usage") as mock_disk_usage:
+            mock_disk_usage.return_value = shutil._ntuple_diskusage(
+                free=512 * 1024 * 1024,
+                total=10 * 1024 * 1024 * 1024,
+                used=9 * 1024 * 1024 * 1024,
+            )
+            has_space, free_bytes = check_disk_space(512 * 1024 * 1024)
+            self.assertTrue(has_space)
+            self.assertEqual(free_bytes, 512 * 1024 * 1024)
+
+    def test_custom_path(self):
+        with patch("shutil.disk_usage") as mock_disk_usage:
+            mock_disk_usage.return_value = shutil._ntuple_diskusage(
+                free=1024, total=10 * 1024 * 1024 * 1024, used=9 * 1024 * 1024 * 1024
+            )
+            check_disk_space(512, path="/tmp")
+            mock_disk_usage.assert_called_once_with("/tmp")

--- a/TEKDB/TEKDB/tests/test_utils.py
+++ b/TEKDB/TEKDB/tests/test_utils.py
@@ -26,6 +26,11 @@ class TestBytesToReadable(TestCase):
     def test_petabytes(self):
         self.assertEqual(bytes_to_readable(1024 * 1024 * 1024 * 1024 * 1024), "1.00 PB")
 
+    def test_1026_petabytes(self):
+        self.assertEqual(
+            bytes_to_readable(1026 * 1024 * 1024 * 1024 * 1024 * 1024), "1026.00 PB"
+        )
+
     def test_zero_bytes(self):
         self.assertEqual(bytes_to_readable(0), "0.00 B")
 

--- a/TEKDB/TEKDB/tests/test_views.py
+++ b/TEKDB/TEKDB/tests/test_views.py
@@ -417,6 +417,20 @@ class ExportTest(TestCase):
         self.assertIn("export_status", response.cookies)
         self.assertEqual(response.cookies["export_status"].value, "error")
 
+    # Test failure in export process due to insufficient disk space
+    def test_not_enough_disk_space_export(self):
+        export_request = create_export_request(self)
+        export_request.user = Users.objects.get(username="admin")
+        with patch("TEKDB.views.shutil.disk_usage") as mock_disk_usage:
+            mock_disk_usage.return_value = shutil._ntuple_diskusage(
+                total=0, used=0, free=0
+            )
+            response = ExportDatabase(export_request, test=False)
+        self.assertEqual(response.status_code, 507)
+        # Assert that the 'export_status=error' cookie is set
+        self.assertIn("export_status", response.cookies)
+        self.assertEqual(response.cookies["export_status"].value, "error")
+
     # Test success in export process
     def test_valid_admin_export(self):
         # dump data

--- a/TEKDB/TEKDB/tests/test_views.py
+++ b/TEKDB/TEKDB/tests/test_views.py
@@ -634,6 +634,15 @@ class ImportDatabaseTest(TransactionTestCase):
                 )
                 response = ImportDatabase(self.import_request)
         self.assertEqual(response.status_code, 507)
+        response.data = json.loads(response.content)
+        self.assertIn(
+            "Not enough disk space to extract the database fixture.",
+            response.data["status_message"],
+        )
+        self.assertIn(
+            "Please free up disk space or contact your IT team.",
+            response.data["status_message"],
+        )
 
     def test_failed_import_insufficient_disk_space_for_media(self):
         self.import_request = self.factory.post(
@@ -666,8 +675,12 @@ class ImportDatabaseTest(TransactionTestCase):
                 response = ImportDatabase(self.import_request)
         self.assertEqual(response.status_code, 507)
         response.data = json.loads(response.content)
-        self.assertEqual(
-            "Not enough disk space to restore media files. The media requires 1.83 MB but only 292.97 KB is available. Please free up disk space or contact your IT team.",
+        self.assertIn(
+            "Not enough disk space to restore media files",
+            response.data["status_message"],
+        )
+        self.assertIn(
+            "Please free up disk space or contact your IT team.",
             response.data["status_message"],
         )
 

--- a/TEKDB/TEKDB/tests/test_views.py
+++ b/TEKDB/TEKDB/tests/test_views.py
@@ -607,6 +607,70 @@ class ImportDatabaseTest(TransactionTestCase):
                 response.data["status_message"],
             )
 
+    def test_failed_import_insufficient_disk_space_for_fixture(self):
+        self.import_request = self.factory.post(
+            reverse("import_database"),
+            {
+                "MEDIA_DIR": self.tempmediadir.name,
+                "content_type": "application/zip",
+                "content_disposition": "attachment; filename=uploaded.dump",
+            },
+            headers={"Authorization": f"Basic {self.credentials}"},
+        )
+        with open(self.zipname, "rb") as z:
+            import_file = InMemoryUploadedFile(
+                z,
+                "import_file",
+                "exported_db.zip",
+                "application/zip",
+                getsize(self.zipname),
+                None,
+            )
+            self.import_request.FILES["import_file"] = import_file
+            self.import_request.user = Users.objects.get(username="admin")
+            with patch("TEKDB.views.shutil.disk_usage") as mock_disk_usage:
+                mock_disk_usage.return_value = shutil._ntuple_diskusage(
+                    total=0, used=0, free=0
+                )
+                response = ImportDatabase(self.import_request)
+        self.assertEqual(response.status_code, 507)
+
+    def test_failed_import_insufficient_disk_space_for_media(self):
+        self.import_request = self.factory.post(
+            reverse("import_database"),
+            {
+                "MEDIA_DIR": self.tempmediadir.name,
+                "content_type": "application/zip",
+                "content_disposition": "attachment; filename=uploaded.dump",
+            },
+            headers={"Authorization": f"Basic {self.credentials}"},
+        )
+        with open(self.zipname, "rb") as z:
+            import_file = InMemoryUploadedFile(
+                z,
+                "import_file",
+                "exported_db.zip",
+                "application/zip",
+                getsize(self.zipname),
+                None,
+            )
+            self.import_request.FILES["import_file"] = import_file
+            self.import_request.user = Users.objects.get(username="admin")
+            import_size = getsize(self.zipname)
+
+            with patch("shutil.disk_usage") as mock_disk_usage:
+                # Simulate sufficient space for fixture but insufficient space for media
+                mock_disk_usage.return_value = shutil._ntuple_diskusage(
+                    total=import_size, used=import_size, free=300000
+                )
+                response = ImportDatabase(self.import_request)
+        self.assertEqual(response.status_code, 507)
+        response.data = json.loads(response.content)
+        self.assertEqual(
+            "Not enough disk space to restore media files. The media requires 1.83 MB but only 292.97 KB is available. Please free up disk space or contact your IT team.",
+            response.data["status_message"],
+        )
+
 
 class GetPlacesGeoJSONTest(TestCase):
     def setUp(self):

--- a/TEKDB/TEKDB/utils.py
+++ b/TEKDB/TEKDB/utils.py
@@ -1,12 +1,14 @@
 import shutil
 
 
+# https://stackoverflow.com/a/1094933
 def bytes_to_readable(num_bytes, suffix="B"):
     """Converts bytes to a human-readable format (e.g., KB, MB, GB)."""
-    for unit in ["", "K", "M", "G", "T", "P"]:
-        if num_bytes < 1024:
+    for unit in ["", "K", "M", "G", "T"]:
+        if abs(num_bytes) < 1024:
             return f"{num_bytes:.2f} {unit}{suffix}"
         num_bytes /= 1024
+    return f"{num_bytes:.2f} P{suffix}"
 
 
 def check_disk_space(required_bytes, path="/"):

--- a/TEKDB/TEKDB/utils.py
+++ b/TEKDB/TEKDB/utils.py
@@ -1,0 +1,15 @@
+import shutil
+
+
+def bytes_to_readable(num_bytes, suffix="B"):
+    """Converts bytes to a human-readable format (e.g., KB, MB, GB)."""
+    for unit in ["", "K", "M", "G", "T", "P"]:
+        if num_bytes < 1024:
+            return f"{num_bytes:.2f} {unit}{suffix}"
+        num_bytes /= 1024
+
+
+def check_disk_space(required_bytes, path="/"):
+    """Return (has_space, free_bytes) for the filesystem containing `path`."""
+    disk = shutil.disk_usage(path)
+    return disk.free >= required_bytes, disk.free

--- a/TEKDB/TEKDB/views.py
+++ b/TEKDB/TEKDB/views.py
@@ -1,5 +1,4 @@
 import contextlib
-import logging
 from dal import autocomplete
 from datetime import datetime
 from django.conf import settings
@@ -23,9 +22,6 @@ from TEKDB.models import (
 import tempfile
 import zipfile
 from configuration.models import Configuration
-
-
-logger = logging.getLogger(__name__)
 
 
 def get_related(request, model_name, id):

--- a/TEKDB/TEKDB/views.py
+++ b/TEKDB/TEKDB/views.py
@@ -107,21 +107,28 @@ def ExportDatabase(request, test=False):
     response = HttpResponse()
     try:
         dumpfile = f"{datestamp}_backup.json"
-        json_buffer = io.StringIO()
-        excludes = getattr(settings, "EXPORT_DUMP_EXCLUDE", [])
-        management.call_command(
-            "dumpdata",
-            exclude=excludes,
-            indent=2,
-            stdout=json_buffer,
-        )
-
-        # Write the zip with compression — no temp directory needed
-        with zipfile.ZipFile(tmp_zip.name, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-            zf.writestr(dumpfile, json_buffer.getvalue())
-            json_buffer.close()  # Free memory as soon as possible
-            for media_file in media_paths:
-                zf.write(media_file)
+        # SpooledTemporaryFile keeps the dump in memory up to max_size,
+        # spilling to disk only if it exceeds that threshold (10 MB ).
+        with tempfile.SpooledTemporaryFile(
+            max_size=10 * 1024 * 1024, mode="w+", encoding="utf-8"
+        ) as spooled:
+            excludes = getattr(settings, "EXPORT_DUMP_EXCLUDE", [])
+            management.call_command(
+                "dumpdata",
+                exclude=excludes,
+                indent=2,
+                stdout=spooled,
+            )
+            spooled.seek(0)
+            # zip up:
+            #   * Data Dump (written directly from the spooled buffer)
+            #   * Media files
+            with zipfile.ZipFile(
+                tmp_zip.name, "w", compression=zipfile.ZIP_DEFLATED
+            ) as zf:
+                zf.writestr(dumpfile, spooled.read())
+                for media_file in media_paths:
+                    zf.write(media_file)
 
         response = FileResponse(open(tmp_zip.name, "rb"))
 

--- a/TEKDB/TEKDB/views.py
+++ b/TEKDB/TEKDB/views.py
@@ -135,44 +135,30 @@ def profile(func):
 
 # Only Admins!
 @user_passes_test(lambda u: u.is_superuser)
-@profile
 def ExportDatabase(request, test=False):
     datestamp = datetime.now().strftime("%Y%m%d")
-    # tmp_zip = tempfile.NamedTemporaryFile(
-    #     delete=False, prefix="{}_backup_".format(datestamp), suffix=".zip"
-    # )
-    _log_storage_snapshot(
-        "export:start",
-        {
-            "temp": tempfile.gettempdir(),
-            "media": settings.MEDIA_ROOT,
-        },
-    )
+
     os.chdir(os.path.join(settings.MEDIA_ROOT, ".."))
     relative_media_directory = settings.MEDIA_ROOT.split(os.path.sep)[-1]
     media_paths = get_all_file_paths(relative_media_directory, cwd=os.getcwd())
     media_size = _get_directory_size(relative_media_directory)
-    print(
-        f"Export source media footprint: files={len(media_paths)}, size={_format_bytes(media_size)}"
-    )
 
     tmp_path = tempfile.gettempdir()
     has_space, free_bytes = check_disk_space(media_size, tmp_path)
     if not has_space:
-        return JsonResponse(
+        response = JsonResponse(
             {
                 "status_code": 507,
                 "status_message": (
-                    "Not enough disk space to export the database. "
-                    "The media directory is {} but only {} is available. "
+                    f"Not enough disk space to export the database. "
+                    f"The media directory is {_format_bytes(media_size)} but only {_format_bytes(free_bytes)} is available. "
                     "Please free up disk space or contact your IT team."
-                ).format(
-                    _format_bytes(media_size),
-                    _format_bytes(free_bytes),
                 ),
             },
             status=507,
         )
+        response.set_cookie("export_status", "error", path="/")
+        return response
 
     tmp_zip = tempfile.NamedTemporaryFile(
         delete=False, prefix="{}_backup_".format(datestamp), suffix=".zip"
@@ -180,31 +166,6 @@ def ExportDatabase(request, test=False):
 
     response = HttpResponse()
     try:
-        # with tempfile.TemporaryDirectory() as tmp_dir:
-        #     # create filename
-        #     dumpfile = "{}_backup.json".format(datestamp)
-        #     dumpfile_location = os.path.join(tmp_dir, dumpfile)
-        #     with open(dumpfile_location, "w") as of:
-        #         excludes = getattr(settings, "EXPORT_DUMP_EXCLUDE", [])
-        #         management.call_command(
-        #             "dumpdata",
-        #             exclude=excludes,
-        #             indent=2,
-        #             stdout=of,
-        #         )
-        #     dump_size_bytes = os.path.getsize(dumpfile_location)
-        #     print(f"Export dumpdata size: {_format_bytes(dump_size_bytes)}")
-        #     # zip up:
-        #     #   * Data Dump file
-        #     #   * Media files
-        #     with zipfile.ZipFile(tmp_zip.name, "w") as zip:
-        #         zip.write(dumpfile_location, dumpfile)
-        #         for media_file in media_paths:
-        #             zip.write(media_file)
-
-        # archive_size_bytes = os.path.getsize(tmp_zip.name)
-
-        # Dump data directly into a StringIO buffer instead of a temp file
         dumpfile = "{}_backup.json".format(datestamp)
         json_buffer = io.StringIO()
         excludes = getattr(settings, "EXPORT_DUMP_EXCLUDE", [])
@@ -214,8 +175,6 @@ def ExportDatabase(request, test=False):
             indent=2,
             stdout=json_buffer,
         )
-        dump_size_bytes = len(json_buffer.getvalue().encode("utf-8"))
-        print(f"Export dumpdata size: {_format_bytes(dump_size_bytes)}")
 
         # Write the zip with compression — no temp directory needed
         with zipfile.ZipFile(tmp_zip.name, "w", compression=zipfile.ZIP_DEFLATED) as zf:
@@ -223,16 +182,6 @@ def ExportDatabase(request, test=False):
             json_buffer.close()  # Free memory as soon as possible
             for media_file in media_paths:
                 zf.write(media_file)
-
-        archive_size_bytes = os.path.getsize(tmp_zip.name)
-        print(f"Export archive size: {_format_bytes(archive_size_bytes)}")
-        _log_storage_snapshot(
-            "export:archive-created",
-            {
-                "temp": tempfile.gettempdir(),
-                "media": settings.MEDIA_ROOT,
-            },
-        )
 
         response = FileResponse(open(tmp_zip.name, "rb"))
 

--- a/TEKDB/TEKDB/views.py
+++ b/TEKDB/TEKDB/views.py
@@ -67,6 +67,12 @@ def get_all_file_paths(directory, cwd=False):
     return file_paths
 
 
+def check_disk_space(required_bytes, path="/"):
+    """Return (has_space, free_bytes) for the filesystem containing `path`."""
+    disk = shutil.disk_usage(path)
+    return disk.free >= required_bytes, disk.free
+
+
 def _format_bytes(num_bytes):
     units = ["B", "KB", "MB", "GB", "TB"]
     value = float(num_bytes)
@@ -132,9 +138,9 @@ def profile(func):
 @profile
 def ExportDatabase(request, test=False):
     datestamp = datetime.now().strftime("%Y%m%d")
-    tmp_zip = tempfile.NamedTemporaryFile(
-        delete=False, prefix="{}_backup_".format(datestamp), suffix=".zip"
-    )
+    # tmp_zip = tempfile.NamedTemporaryFile(
+    #     delete=False, prefix="{}_backup_".format(datestamp), suffix=".zip"
+    # )
     _log_storage_snapshot(
         "export:start",
         {
@@ -145,33 +151,78 @@ def ExportDatabase(request, test=False):
     os.chdir(os.path.join(settings.MEDIA_ROOT, ".."))
     relative_media_directory = settings.MEDIA_ROOT.split(os.path.sep)[-1]
     media_paths = get_all_file_paths(relative_media_directory, cwd=os.getcwd())
-    media_size_bytes = _get_directory_size(settings.MEDIA_ROOT)
+    media_size = _get_directory_size(relative_media_directory)
     print(
-        f"Export source media footprint: files={len(media_paths)}, size={_format_bytes(media_size_bytes)}"
+        f"Export source media footprint: files={len(media_paths)}, size={_format_bytes(media_size)}"
     )
+
+    tmp_path = tempfile.gettempdir()
+    has_space, free_bytes = check_disk_space(media_size, tmp_path)
+    if not has_space:
+        return JsonResponse(
+            {
+                "status_code": 507,
+                "status_message": (
+                    "Not enough disk space to export the database. "
+                    "The media directory is {} but only {} is available. "
+                    "Please free up disk space or contact your IT team."
+                ).format(
+                    _format_bytes(media_size),
+                    _format_bytes(free_bytes),
+                ),
+            },
+            status=507,
+        )
+
+    tmp_zip = tempfile.NamedTemporaryFile(
+        delete=False, prefix="{}_backup_".format(datestamp), suffix=".zip"
+    )
+
     response = HttpResponse()
     try:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            # create filename
-            dumpfile = "{}_backup.json".format(datestamp)
-            dumpfile_location = os.path.join(tmp_dir, dumpfile)
-            with open(dumpfile_location, "w") as of:
-                excludes = getattr(settings, "EXPORT_DUMP_EXCLUDE", [])
-                management.call_command(
-                    "dumpdata",
-                    exclude=excludes,
-                    indent=2,
-                    stdout=of,
-                )
-            dump_size_bytes = os.path.getsize(dumpfile_location)
-            print(f"Export dumpdata size: {_format_bytes(dump_size_bytes)}")
-            # zip up:
-            #   * Data Dump file
-            #   * Media files
-            with zipfile.ZipFile(tmp_zip.name, "w") as zip:
-                zip.write(dumpfile_location, dumpfile)
-                for media_file in media_paths:
-                    zip.write(media_file)
+        # with tempfile.TemporaryDirectory() as tmp_dir:
+        #     # create filename
+        #     dumpfile = "{}_backup.json".format(datestamp)
+        #     dumpfile_location = os.path.join(tmp_dir, dumpfile)
+        #     with open(dumpfile_location, "w") as of:
+        #         excludes = getattr(settings, "EXPORT_DUMP_EXCLUDE", [])
+        #         management.call_command(
+        #             "dumpdata",
+        #             exclude=excludes,
+        #             indent=2,
+        #             stdout=of,
+        #         )
+        #     dump_size_bytes = os.path.getsize(dumpfile_location)
+        #     print(f"Export dumpdata size: {_format_bytes(dump_size_bytes)}")
+        #     # zip up:
+        #     #   * Data Dump file
+        #     #   * Media files
+        #     with zipfile.ZipFile(tmp_zip.name, "w") as zip:
+        #         zip.write(dumpfile_location, dumpfile)
+        #         for media_file in media_paths:
+        #             zip.write(media_file)
+
+        # archive_size_bytes = os.path.getsize(tmp_zip.name)
+
+        # Dump data directly into a StringIO buffer instead of a temp file
+        dumpfile = "{}_backup.json".format(datestamp)
+        json_buffer = io.StringIO()
+        excludes = getattr(settings, "EXPORT_DUMP_EXCLUDE", [])
+        management.call_command(
+            "dumpdata",
+            exclude=excludes,
+            indent=2,
+            stdout=json_buffer,
+        )
+        dump_size_bytes = len(json_buffer.getvalue().encode("utf-8"))
+        print(f"Export dumpdata size: {_format_bytes(dump_size_bytes)}")
+
+        # Write the zip with compression — no temp directory needed
+        with zipfile.ZipFile(tmp_zip.name, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(dumpfile, json_buffer.getvalue())
+            json_buffer.close()  # Free memory as soon as possible
+            for media_file in media_paths:
+                zf.write(media_file)
 
         archive_size_bytes = os.path.getsize(tmp_zip.name)
         print(f"Export archive size: {_format_bytes(archive_size_bytes)}")
@@ -272,9 +323,74 @@ def ImportDatabase(request):
                             },
                             status=status_code,
                         )
+                    # --- Pre-flight disk space check ---
+                    # We need space for the JSON fixture in tempdir plus
+                    # the media files written to MEDIA_ROOT. Calculate the
+                    # uncompressed size of the fixture and media separately.
                     fixture_name = non_media[0]
+                    media_members = [
+                        m
+                        for m in zip.namelist()
+                        if m.startswith("media/") and not m.endswith("/")
+                    ]
+
+                    fixture_size = sum(
+                        info.file_size
+                        for info in zip.infolist()
+                        if info.filename == fixture_name
+                    )
+                    media_size = sum(
+                        info.file_size
+                        for info in zip.infolist()
+                        if info.filename in media_members
+                    )
+
+                    # Check temp directory space (for the extracted fixture)
+                    tmp_path = tempfile.gettempdir()
+                    has_tmp_space, tmp_free = check_disk_space(fixture_size, tmp_path)
+                    if not has_tmp_space:
+                        status_code = 507
+                        status_message = (
+                            "Not enough disk space to extract the database fixture. "
+                            "The fixture requires {} but only {} is available in the "
+                            "temp directory. Please free up disk space or contact your "
+                            "IT team."
+                        ).format(
+                            _format_bytes(fixture_size),
+                            _format_bytes(tmp_free),
+                        )
+                        return JsonResponse(
+                            {
+                                "status_code": status_code,
+                                "status_message": status_message,
+                            },
+                            status=status_code,
+                        )
+
+                    # Check media directory space (for the restored media)
+                    has_media_space, media_free = check_disk_space(
+                        media_size, media_dir
+                    )
+                    if not has_media_space:
+                        status_code = 507
+                        status_message = (
+                            "Not enough disk space to restore media files. "
+                            "The media requires {} but only {} is available. "
+                            "Please free up disk space or contact your IT team."
+                        ).format(
+                            _format_bytes(media_size),
+                            _format_bytes(media_free),
+                        )
+                        return JsonResponse(
+                            {
+                                "status_code": status_code,
+                                "status_message": status_message,
+                            },
+                            status=status_code,
+                        )
+
                     try:
-                        zip.extractall(tempdir)
+                        zip.extract(fixture_name, tempdir)
                         extracted_size_bytes = _get_directory_size(tempdir)
                         print(
                             f"Import extracted payload size: {_format_bytes(extracted_size_bytes)}"
@@ -288,7 +404,7 @@ def ImportDatabase(request):
                         )
                     except Exception as e:
                         status_code = 500
-                        status_message = 'Unable to unzip the provided file. Be sure it is a zipped file containing a .json representing the database and a "media" directory containing any static files. {}'.format(
+                        status_message = "Unable to extract the fixture from the provided file. {}".format(
                             e
                         )
                         return JsonResponse(
@@ -355,12 +471,22 @@ def ImportDatabase(request):
                         )
 
                     try:
-                        # Copy media into MEDIA dir
-                        shutil.copytree(
-                            os.path.join(tempdir, "media"),
-                            media_dir,
-                            dirs_exist_ok=True,
-                        )
+                        # Copy media files directly from the zip into
+                        # MEDIA_ROOT one at a time, instead of extracting
+                        # everything to a temp dir first
+                        for member in media_members:
+                            # Strip the leading "media/" prefix to get
+                            # the relative path inside MEDIA_ROOT
+                            relative_path = member[len("media/") :]
+                            if not relative_path:
+                                continue
+                            target_path = os.path.join(media_dir, relative_path)
+                            os.makedirs(os.path.dirname(target_path), exist_ok=True)
+                            with (
+                                zip.open(member) as src,
+                                open(target_path, "wb") as dst,
+                            ):
+                                shutil.copyfileobj(src, dst)
                         media_size_after_import = _get_directory_size(media_dir)
                         print(
                             f"Import media footprint after restore: {_format_bytes(media_size_after_import)}"

--- a/TEKDB/TEKDB/views.py
+++ b/TEKDB/TEKDB/views.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import management
 from django.db import connection
 from django.db.models import Q
-from django.http import HttpResponse, FileResponse, JsonResponse
+from django.http import FileResponse, HttpResponse, JsonResponse
 import io
 import os
 import shutil
@@ -23,6 +23,16 @@ from TEKDB.models import (
 import tempfile
 import zipfile
 from configuration.models import Configuration
+
+
+def chunk_text_file(text_file, chunk_size=64 * 1024):
+    """Generator that yields chunks of a text file as bytes"""
+    text_file.seek(0)
+    while True:
+        chunk = text_file.read(chunk_size)
+        if not chunk:
+            return
+        yield chunk.encode("utf-8")
 
 
 def get_related(request, model_name, id):
@@ -119,16 +129,17 @@ def ExportDatabase(request, test=False):
                 indent=2,
                 stdout=spooled,
             )
-            spooled.seek(0)
             # zip up:
             #   * Data Dump (written directly from the spooled buffer)
             #   * Media files
             with zipfile.ZipFile(
                 tmp_zip.name, "w", compression=zipfile.ZIP_DEFLATED
-            ) as zf:
-                zf.writestr(dumpfile, spooled.read())
+            ) as zip:
+                with zip.open(dumpfile, "w") as dump_entry:
+                    for chunk in chunk_text_file(spooled):
+                        dump_entry.write(chunk)
                 for media_file in media_paths:
-                    zf.write(media_file)
+                    zip.write(media_file)
 
         response = FileResponse(open(tmp_zip.name, "rb"))
 

--- a/TEKDB/TEKDB/views.py
+++ b/TEKDB/TEKDB/views.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 from dal import autocomplete
 from datetime import datetime
 from django.conf import settings
@@ -11,6 +12,7 @@ from django.http import HttpResponse, FileResponse, JsonResponse
 import io
 import os
 import shutil
+import psutil
 from TEKDB.models import (
     Citations,
     Media,
@@ -22,6 +24,9 @@ from TEKDB.models import (
 import tempfile
 import zipfile
 from configuration.models import Configuration
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_related(request, model_name, id):
@@ -62,16 +67,88 @@ def get_all_file_paths(directory, cwd=False):
     return file_paths
 
 
+def _format_bytes(num_bytes):
+    units = ["B", "KB", "MB", "GB", "TB"]
+    value = float(num_bytes)
+    for unit in units:
+        if value < 1024 or unit == units[-1]:
+            return f"{value:.2f} {unit}"
+        value /= 1024
+
+
+def _get_directory_size(path):
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for filename in files:
+            filepath = os.path.join(root, filename)
+            try:
+                total += os.path.getsize(filepath)
+            except OSError:
+                continue
+    return total
+
+
+def _log_storage_snapshot(stage, monitored_paths):
+    disk_info = {}
+    for label, path in monitored_paths.items():
+        try:
+            usage = shutil.disk_usage(path)
+            disk_info[label] = {
+                "path": path,
+                "free": _format_bytes(usage.free),
+                "used": _format_bytes(usage.used),
+                "total": _format_bytes(usage.total),
+            }
+        except OSError:
+            disk_info[label] = {"path": path, "error": "unavailable"}
+    print(f"Storage snapshot [{stage}]: {disk_info}")
+
+
+# inner psutil function
+def process_memory():
+    process = psutil.Process(os.getpid())
+    mem_info = process.memory_info()
+    return mem_info.rss
+
+
+# decorator function
+def profile(func):
+    def wrapper(*args, **kwargs):
+
+        mem_before = process_memory()
+        result = func(*args, **kwargs)
+        mem_after = process_memory()
+        print(
+            f"{func.__name__}: consumed memory: {mem_before:,} -> {mem_after:,} (delta: {mem_after - mem_before:,})"
+        )
+
+        return result
+
+    return wrapper
+
+
 # Only Admins!
 @user_passes_test(lambda u: u.is_superuser)
+@profile
 def ExportDatabase(request, test=False):
     datestamp = datetime.now().strftime("%Y%m%d")
     tmp_zip = tempfile.NamedTemporaryFile(
         delete=False, prefix="{}_backup_".format(datestamp), suffix=".zip"
     )
+    _log_storage_snapshot(
+        "export:start",
+        {
+            "temp": tempfile.gettempdir(),
+            "media": settings.MEDIA_ROOT,
+        },
+    )
     os.chdir(os.path.join(settings.MEDIA_ROOT, ".."))
     relative_media_directory = settings.MEDIA_ROOT.split(os.path.sep)[-1]
     media_paths = get_all_file_paths(relative_media_directory, cwd=os.getcwd())
+    media_size_bytes = _get_directory_size(settings.MEDIA_ROOT)
+    print(
+        f"Export source media footprint: files={len(media_paths)}, size={_format_bytes(media_size_bytes)}"
+    )
     response = HttpResponse()
     try:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -86,6 +163,8 @@ def ExportDatabase(request, test=False):
                     indent=2,
                     stdout=of,
                 )
+            dump_size_bytes = os.path.getsize(dumpfile_location)
+            print(f"Export dumpdata size: {_format_bytes(dump_size_bytes)}")
             # zip up:
             #   * Data Dump file
             #   * Media files
@@ -93,6 +172,16 @@ def ExportDatabase(request, test=False):
                 zip.write(dumpfile_location, dumpfile)
                 for media_file in media_paths:
                     zip.write(media_file)
+
+        archive_size_bytes = os.path.getsize(tmp_zip.name)
+        print(f"Export archive size: {_format_bytes(archive_size_bytes)}")
+        _log_storage_snapshot(
+            "export:archive-created",
+            {
+                "temp": tempfile.gettempdir(),
+                "media": settings.MEDIA_ROOT,
+            },
+        )
 
         response = FileResponse(open(tmp_zip.name, "rb"))
 
@@ -118,6 +207,7 @@ def getDBTruncateCommand():
 
 # Only Admins!
 @user_passes_test(lambda u: u.is_superuser)
+@profile
 def ImportDatabase(request):
     status_code = 500
     status_message = "An unknown error occurred."
@@ -138,6 +228,13 @@ def ImportDatabase(request):
             media_dir = settings.MEDIA_ROOT
         # Unzip file
         if "import_file" in request.FILES.keys():
+            _log_storage_snapshot(
+                "import:start",
+                {
+                    "temp": tempfile.gettempdir(),
+                    "media": media_dir,
+                },
+            )
             with tempfile.TemporaryDirectory() as tempdir:
                 try:
                     tmp_zip_file = tempfile.NamedTemporaryFile(
@@ -146,6 +243,9 @@ def ImportDatabase(request):
                     for chunk in request.FILES["import_file"].chunks():
                         tmp_zip_file.write(chunk)
                     tmp_zip_file.seek(0)
+                    print(
+                        f"Import uploaded archive size: {_format_bytes(tmp_zip_file.tell())}"
+                    )
 
                 except Exception as e:
                     status_code = 500
@@ -175,6 +275,17 @@ def ImportDatabase(request):
                     fixture_name = non_media[0]
                     try:
                         zip.extractall(tempdir)
+                        extracted_size_bytes = _get_directory_size(tempdir)
+                        print(
+                            f"Import extracted payload size: {_format_bytes(extracted_size_bytes)}"
+                        )
+                        _log_storage_snapshot(
+                            "import:after-extract",
+                            {
+                                "temp": tempfile.gettempdir(),
+                                "media": media_dir,
+                            },
+                        )
                     except Exception as e:
                         status_code = 500
                         status_message = 'Unable to unzip the provided file. Be sure it is a zipped file containing a .json representing the database and a "media" directory containing any static files. {}'.format(
@@ -249,6 +360,17 @@ def ImportDatabase(request):
                             os.path.join(tempdir, "media"),
                             media_dir,
                             dirs_exist_ok=True,
+                        )
+                        media_size_after_import = _get_directory_size(media_dir)
+                        print(
+                            f"Import media footprint after restore: {_format_bytes(media_size_after_import)}"
+                        )
+                        _log_storage_snapshot(
+                            "import:complete",
+                            {
+                                "temp": tempfile.gettempdir(),
+                                "media": media_dir,
+                            },
                         )
                     except Exception as e:
                         status_code = 500

--- a/TEKDB/TEKDB/views.py
+++ b/TEKDB/TEKDB/views.py
@@ -12,7 +12,6 @@ from django.http import HttpResponse, FileResponse, JsonResponse
 import io
 import os
 import shutil
-import psutil
 from TEKDB.models import (
     Citations,
     Media,
@@ -94,45 +93,6 @@ def _get_directory_size(path):
     return total
 
 
-def _log_storage_snapshot(stage, monitored_paths):
-    disk_info = {}
-    for label, path in monitored_paths.items():
-        try:
-            usage = shutil.disk_usage(path)
-            disk_info[label] = {
-                "path": path,
-                "free": _format_bytes(usage.free),
-                "used": _format_bytes(usage.used),
-                "total": _format_bytes(usage.total),
-            }
-        except OSError:
-            disk_info[label] = {"path": path, "error": "unavailable"}
-    print(f"Storage snapshot [{stage}]: {disk_info}")
-
-
-# inner psutil function
-def process_memory():
-    process = psutil.Process(os.getpid())
-    mem_info = process.memory_info()
-    return mem_info.rss
-
-
-# decorator function
-def profile(func):
-    def wrapper(*args, **kwargs):
-
-        mem_before = process_memory()
-        result = func(*args, **kwargs)
-        mem_after = process_memory()
-        print(
-            f"{func.__name__}: consumed memory: {mem_before:,} -> {mem_after:,} (delta: {mem_after - mem_before:,})"
-        )
-
-        return result
-
-    return wrapper
-
-
 # Only Admins!
 @user_passes_test(lambda u: u.is_superuser)
 def ExportDatabase(request, test=False):
@@ -146,14 +106,13 @@ def ExportDatabase(request, test=False):
     tmp_path = tempfile.gettempdir()
     has_space, free_bytes = check_disk_space(media_size, tmp_path)
     if not has_space:
+        status_code = 507
+        status_message = f"Not enough disk space to export the database. The media directory is {_format_bytes(media_size)} but only {_format_bytes(free_bytes)} is available. Please free up disk space or contact your IT team."
+        print(status_message)
         response = JsonResponse(
             {
-                "status_code": 507,
-                "status_message": (
-                    f"Not enough disk space to export the database. "
-                    f"The media directory is {_format_bytes(media_size)} but only {_format_bytes(free_bytes)} is available. "
-                    "Please free up disk space or contact your IT team."
-                ),
+                "status_code": status_code,
+                "status_message": status_message,
             },
             status=507,
         )
@@ -161,12 +120,12 @@ def ExportDatabase(request, test=False):
         return response
 
     tmp_zip = tempfile.NamedTemporaryFile(
-        delete=False, prefix="{}_backup_".format(datestamp), suffix=".zip"
+        delete=False, prefix=f"{datestamp}_backup_", suffix=".zip"
     )
 
     response = HttpResponse()
     try:
-        dumpfile = "{}_backup.json".format(datestamp)
+        dumpfile = f"{datestamp}_backup.json"
         json_buffer = io.StringIO()
         excludes = getattr(settings, "EXPORT_DUMP_EXCLUDE", [])
         management.call_command(
@@ -207,7 +166,6 @@ def getDBTruncateCommand():
 
 # Only Admins!
 @user_passes_test(lambda u: u.is_superuser)
-@profile
 def ImportDatabase(request):
     status_code = 500
     status_message = "An unknown error occurred."
@@ -228,13 +186,6 @@ def ImportDatabase(request):
             media_dir = settings.MEDIA_ROOT
         # Unzip file
         if "import_file" in request.FILES.keys():
-            _log_storage_snapshot(
-                "import:start",
-                {
-                    "temp": tempfile.gettempdir(),
-                    "media": media_dir,
-                },
-            )
             with tempfile.TemporaryDirectory() as tempdir:
                 try:
                     tmp_zip_file = tempfile.NamedTemporaryFile(
@@ -243,15 +194,10 @@ def ImportDatabase(request):
                     for chunk in request.FILES["import_file"].chunks():
                         tmp_zip_file.write(chunk)
                     tmp_zip_file.seek(0)
-                    print(
-                        f"Import uploaded archive size: {_format_bytes(tmp_zip_file.tell())}"
-                    )
 
                 except Exception as e:
                     status_code = 500
-                    status_message = 'Unable to read the provided file. Be sure it is a zipped file containing a .json representing the database and a "media" directory containing any static files. {}'.format(
-                        e
-                    )
+                    status_message = f'Unable to read the provided file. Be sure it is a zipped file containing a .json representing the database and a "media" directory containing any static files. {e}'
                     return JsonResponse(
                         {"status_code": status_code, "status_message": status_message},
                         status=status_code,
@@ -297,17 +243,11 @@ def ImportDatabase(request):
                     # Check temp directory space (for the extracted fixture)
                     tmp_path = tempfile.gettempdir()
                     has_tmp_space, tmp_free = check_disk_space(fixture_size, tmp_path)
+
                     if not has_tmp_space:
                         status_code = 507
-                        status_message = (
-                            "Not enough disk space to extract the database fixture. "
-                            "The fixture requires {} but only {} is available in the "
-                            "temp directory. Please free up disk space or contact your "
-                            "IT team."
-                        ).format(
-                            _format_bytes(fixture_size),
-                            _format_bytes(tmp_free),
-                        )
+                        status_message = f"Not enough disk space to extract the database fixture. The fixture requires {_format_bytes(fixture_size)} but only {_format_bytes(tmp_free)} is available in the temp directory. Please free up disk space or contact your IT team."
+
                         return JsonResponse(
                             {
                                 "status_code": status_code,
@@ -320,16 +260,10 @@ def ImportDatabase(request):
                     has_media_space, media_free = check_disk_space(
                         media_size, media_dir
                     )
+
                     if not has_media_space:
                         status_code = 507
-                        status_message = (
-                            "Not enough disk space to restore media files. "
-                            "The media requires {} but only {} is available. "
-                            "Please free up disk space or contact your IT team."
-                        ).format(
-                            _format_bytes(media_size),
-                            _format_bytes(media_free),
-                        )
+                        status_message = f"Not enough disk space to restore media files. The media requires {_format_bytes(media_size)} but only {_format_bytes(media_free)} is available. Please free up disk space or contact your IT team."
                         return JsonResponse(
                             {
                                 "status_code": status_code,
@@ -340,21 +274,11 @@ def ImportDatabase(request):
 
                     try:
                         zip.extract(fixture_name, tempdir)
-                        extracted_size_bytes = _get_directory_size(tempdir)
-                        print(
-                            f"Import extracted payload size: {_format_bytes(extracted_size_bytes)}"
-                        )
-                        _log_storage_snapshot(
-                            "import:after-extract",
-                            {
-                                "temp": tempfile.gettempdir(),
-                                "media": media_dir,
-                            },
-                        )
+
                     except Exception as e:
                         status_code = 500
-                        status_message = "Unable to extract the fixture from the provided file. {}".format(
-                            e
+                        status_message = (
+                            f"Unable to extract the fixture from the provided file. {e}"
                         )
                         return JsonResponse(
                             {
@@ -371,9 +295,7 @@ def ImportDatabase(request):
                                 cursor.execute(sql_command)
                     except Exception as e:
                         status_code = 500
-                        status_message = "Error while attempting to remove old database data. New data has NOT been imported. Significant data loss possible. Please check your import file and try again. {}".format(
-                            e
-                        )
+                        status_message = f"Error while attempting to remove old database data. New data has NOT been imported. Significant data loss possible. Please check your import file and try again. {e}"
                         return JsonResponse(
                             {
                                 "status_code": status_code,
@@ -408,9 +330,7 @@ def ImportDatabase(request):
                         ContentType.objects.clear_cache()
                     except Exception as e:
                         status_code = 500
-                        status_message = "Error while loading in data from provided zipfile. Your old data has been removed. Please coordinate with IT to restore your database, and share this error message with them:\n {}".format(
-                            e
-                        )
+                        status_message = f"Error while loading in data from provided zipfile. Your old data has been removed. Please coordinate with IT to restore your database, and share this error message with them:\n {e}"
                         return JsonResponse(
                             {
                                 "status_code": status_code,
@@ -436,22 +356,10 @@ def ImportDatabase(request):
                                 open(target_path, "wb") as dst,
                             ):
                                 shutil.copyfileobj(src, dst)
-                        media_size_after_import = _get_directory_size(media_dir)
-                        print(
-                            f"Import media footprint after restore: {_format_bytes(media_size_after_import)}"
-                        )
-                        _log_storage_snapshot(
-                            "import:complete",
-                            {
-                                "temp": tempfile.gettempdir(),
-                                "media": media_dir,
-                            },
-                        )
+
                     except Exception as e:
                         status_code = 500
-                        status_message = "Error while restoring your media files. Please work with IT to restore these, providing them your zipfile and this error message:\n {}".format(
-                            e
-                        )
+                        status_message = f"Error while restoring your media files. Please work with IT to restore these, providing them your zipfile and this error message:\n {e}"
                         return JsonResponse(
                             {
                                 "status_code": status_code,

--- a/TEKDB/TEKDB/views.py
+++ b/TEKDB/TEKDB/views.py
@@ -63,9 +63,9 @@ def get_all_file_paths(directory, cwd=False):
     return file_paths
 
 
-def get_directory_size(path):
+def get_directory_size(directory):
     total = 0
-    for root, _dirs, files in os.walk(path):
+    for root, directories, files in os.walk(directory):
         for filename in files:
             filepath = os.path.join(root, filename)
             try:

--- a/TEKDB/TEKDB/views.py
+++ b/TEKDB/TEKDB/views.py
@@ -11,6 +11,7 @@ from django.http import HttpResponse, FileResponse, JsonResponse
 import io
 import os
 import shutil
+from TEKDB.utils import bytes_to_readable, check_disk_space
 from TEKDB.models import (
     Citations,
     Media,
@@ -62,22 +63,7 @@ def get_all_file_paths(directory, cwd=False):
     return file_paths
 
 
-def check_disk_space(required_bytes, path="/"):
-    """Return (has_space, free_bytes) for the filesystem containing `path`."""
-    disk = shutil.disk_usage(path)
-    return disk.free >= required_bytes, disk.free
-
-
-def _format_bytes(num_bytes):
-    units = ["B", "KB", "MB", "GB", "TB"]
-    value = float(num_bytes)
-    for unit in units:
-        if value < 1024 or unit == units[-1]:
-            return f"{value:.2f} {unit}"
-        value /= 1024
-
-
-def _get_directory_size(path):
+def get_directory_size(path):
     total = 0
     for root, _dirs, files in os.walk(path):
         for filename in files:
@@ -97,14 +83,13 @@ def ExportDatabase(request, test=False):
     os.chdir(os.path.join(settings.MEDIA_ROOT, ".."))
     relative_media_directory = settings.MEDIA_ROOT.split(os.path.sep)[-1]
     media_paths = get_all_file_paths(relative_media_directory, cwd=os.getcwd())
-    media_size = _get_directory_size(relative_media_directory)
+    media_size = get_directory_size(relative_media_directory)
 
     tmp_path = tempfile.gettempdir()
     has_space, free_bytes = check_disk_space(media_size, tmp_path)
     if not has_space:
         status_code = 507
-        status_message = f"Not enough disk space to export the database. The media directory is {_format_bytes(media_size)} but only {_format_bytes(free_bytes)} is available. Please free up disk space or contact your IT team."
-        print(status_message)
+        status_message = f"Not enough disk space to export the database. The media directory is {bytes_to_readable(media_size)} but only {bytes_to_readable(free_bytes)} is available. Please free up disk space or contact your IT team."
         response = JsonResponse(
             {
                 "status_code": status_code,
@@ -242,7 +227,7 @@ def ImportDatabase(request):
 
                     if not has_tmp_space:
                         status_code = 507
-                        status_message = f"Not enough disk space to extract the database fixture. The fixture requires {_format_bytes(fixture_size)} but only {_format_bytes(tmp_free)} is available in the temp directory. Please free up disk space or contact your IT team."
+                        status_message = f"Not enough disk space to extract the database fixture. The fixture requires {bytes_to_readable(fixture_size)} but only {bytes_to_readable(tmp_free)} is available in the temp directory. Please free up disk space or contact your IT team."
 
                         return JsonResponse(
                             {
@@ -259,7 +244,7 @@ def ImportDatabase(request):
 
                     if not has_media_space:
                         status_code = 507
-                        status_message = f"Not enough disk space to restore media files. The media requires {_format_bytes(media_size)} but only {_format_bytes(media_free)} is available. Please free up disk space or contact your IT team."
+                        status_message = f"Not enough disk space to restore media files. The media requires {bytes_to_readable(media_size)} but only {bytes_to_readable(media_free)} is available. Please free up disk space or contact your IT team."
                         return JsonResponse(
                             {
                                 "status_code": status_code,

--- a/TEKDB/explore/templatetags/disk_space_report.py
+++ b/TEKDB/explore/templatetags/disk_space_report.py
@@ -1,16 +1,9 @@
 from django import template
 import psutil
 
+from TEKDB.utils import bytes_to_readable
 
 register = template.Library()
-
-
-def bytes_to_readable(num_bytes, suffix="B"):
-    """Converts bytes to a human-readable format (e.g., KB, MB, GB)."""
-    for unit in ["", "K", "M", "G", "T", "P"]:
-        if num_bytes < 1024:
-            return f"{num_bytes:.2f} {unit}{suffix}"
-        num_bytes /= 1024
 
 
 @register.simple_tag(name="disk_space_report")


### PR DESCRIPTION
## Description

This takes the approach of performing pre-flight checks before doing an import or export to ensure that we have enough disk space for those operations. I will have a follow up PR to make any changes to nginx configs to support large data imports and exports. 

### Changes to export functionality

- Adds checks before processing an export of the database to see if there is enough disk space to execute the function. 
- TIL about `SpooledTemporaryFile`! Uses a `SpooledTemporaryFile` instead of a file in a `TemporaryDirectory` when exporting the database fixture to only have this data in memory if it is less than 10 MB. If the data dump is greater than 10 MB it will be temporarily written to disk.  
- Compresses the zip file with `zipfile.ZIP_DEFLATED`


### Changes to import functionality 
- Adds checks before processing an import of the database to see if there is enough disk space to execute the function.
- only extracts the database fixture
- copies media files one at a time, instead of writing to a temporary directory to save on disk space

### Tech debt improvements

- Consolidates the `bytes_to_readable` function to a util, used in several places. Also adds unit tests for this function. 
- Uses f-strings instead of `format()`


[asana task](https://app.asana.com/1/5541737610303/project/1212860200263868/task/1211526062018069?focus=true)

