### PR TITLE
add message if delete_expired_chunks directory is not found

### DIFF
--- a/TEKDB/TEKDB/tasks.py
+++ b/TEKDB/TEKDB/tasks.py
@@ -22,7 +22,7 @@ def delete_expired_chunks(self, max_age_hours=24):
 
     if not os.path.isdir(target_dir):
         logger.error(f"Target directory does not exist: {target_dir}")
-        return
+        return "Target directory not found; skipping cleanup."
 
     logger.info(
         f"Starting cleanup of '{target_dir}' — files older than {max_age_hours}h"

--- a/TEKDB/TEKDB/tests/test_tasks.py
+++ b/TEKDB/TEKDB/tests/test_tasks.py
@@ -12,7 +12,7 @@ class DeleteExpiredChunksTest(TestCase):
             MEDIA_ROOT="/nonexistent", ADMIN_RESUMABLE_CHUNK_FOLDER="does_not_exist"
         ):
             result = delete_expired_chunks.run(max_age_hours=24)
-        self.assertIsNone(result)
+        self.assertEqual(result, "Target directory not found; skipping cleanup.")
 
     def test_deletes_expired_chunks_and_skips_new(self):
         import tempfile


### PR DESCRIPTION
Prior to the change, in the admin UI for the task result, the Result Data displayed "null" if there is no resumable chunk directory. This change displays a message for that case

<img width="731" height="99" alt="Screenshot 2026-04-09 at 1 11 20 PM" src="https://github.com/user-attachments/assets/ab0869ec-821a-4ec0-9342-874f4b6924e1" />
