### PR TITLE
set uwsgi_request_buffering to off

### DIFF
--- a/proxy/default.conf.template
+++ b/proxy/default.conf.template
@@ -18,6 +18,11 @@ server {
   location /media {
     alias /vol/static/media;
   }
+  location /import_database/ {
+    uwsgi_request_buffering off;
+    uwsgi_pass web:8000;
+    include /etc/nginx/uwsgi_params;
+  }
   location / {
     uwsgi_pass web:8000;
     include /etc/nginx/uwsgi_params;


### PR DESCRIPTION
A WIP to disable nginx from writing to a temp file and just sending the request to the django web server. The django web server should catch the out of disk error 

[docs:](https://nginx.org/en/docs/http/ngx_http_uwsgi_module.html#uwsgi_request_buffering)

> When buffering is disabled, the request body is sent to the uwsgi server immediately as it is received. In this case, the request cannot be passed to the [next server](https://nginx.org/en/docs/http/ngx_http_uwsgi_module.html#uwsgi_next_upstream) if nginx already started sending the request body.