### PR TITLE
Logout after import fixes

### DIFF
--- a/TEKDB/TEKDB/static/admin/js/admin_index.js
+++ b/TEKDB/TEKDB/static/admin/js/admin_index.js
@@ -107,7 +107,7 @@ $(function () {
 
     $("#modalTitle").text("Import Database");
     $("#modalBody").html(importText);
-
+    let showSpinner = true;
     $("#continueImport").click(function () {
       // prevent closing the modal after verifying import
       $("#exportImportModal").modal({
@@ -117,12 +117,13 @@ $(function () {
 
       // add spinner to the button
       // change button text to "Importing..."
-      $("#continueImport").html(
-        `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Importing...`
-      );
-      $("#continueImport").prop("disabled", true);
-      $("#closeModalButton").prop("disabled", true);
-
+      if (showSpinner) {
+        $("#continueImport").html(
+          `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Importing...`
+        );
+        $("#continueImport").prop("disabled", true);
+        $("#closeModalButton").prop("disabled", true);
+      }
       const form = $("#import-database-form");
       $.ajax({
         url: "/import_database/",
@@ -142,6 +143,7 @@ $(function () {
               $("#modalNextSteps").html(
                 `<p class='text-success'>Import successful. You may now be logged out.</p>`
               );
+              showSpinner = false;
               $("#continueImport").html("Log out");
               $("#continueImport").click(function () {
                 location.reload(true);
@@ -150,10 +152,12 @@ $(function () {
               $("#modalNextSteps").html(
                 `<p class='text-danger'>Import failed with error code ${data.status_code}.</p><p class='text-danger'>${data.status_message}</p>`
               );
+              showSpinner = false;
               resetModal();
             }
           } else {
             $("#modalNextSteps").html(unexpectedError(status));
+            showSpinner = false;
             resetModal();
           }
         },

--- a/TEKDB/TEKDB/static/admin/js/admin_index.js
+++ b/TEKDB/TEKDB/static/admin/js/admin_index.js
@@ -51,6 +51,24 @@ const exportInfoText = `The Export Database Tool is designed to support saving t
         a safe and secure practice for regular backups, which may or may 
         not involve this tool.`;
 
+function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+        var cookies = document.cookie.split(';');
+        for (var i = 0; i < cookies.length; i++) {
+            var cookie = jQuery.trim(cookies[i]);
+            // Does this cookie string begin with the name we want?
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+
+var csrftoken = getCookie('csrftoken');
+
 $(function () {
   const unexpectedError = (statusCode, statusMessage = "") => {
     return `<p class='text-danger'>Unexpected error occurred: ${statusCode}</p><p class='text-danger'>${statusMessage}</p>`;
@@ -146,7 +164,16 @@ $(function () {
               showSpinner = false;
               $("#continueImport").html("Log out");
               $("#continueImport").click(function () {
-                location.reload(true);
+                $.ajax({
+                  url: "/logout/",
+                  type: "POST",
+                  headers: {'X-CSRFToken': csrftoken},
+                  mode: 'same-origin',
+                  success: function () {
+                    // force reload to update to logged out state
+                    location.reload(true);
+                  },
+                });
               });
             } else {
               $("#modalNextSteps").html(


### PR DESCRIPTION
Addresses the following bugs:

1. [[task](https://app.asana.com/1/5541737610303/project/1212860200263868/task/1214037490846871?focus=true)] After a successful import and the user clicking "log out", the button in the modal would briefly display the "Importing..." spinner. I added logic to only display the spinner during the import step.
2. [[task](https://app.asana.com/1/5541737610303/project/1199679790289799/task/1215244975059209?focus=true)]After a successful import, the intended functionality is for the user to be logged out to ensure that they see the latest database state. This was not happening consistently with `location.reload(true);`. I added a request to the `logout` url to ensure that a user is logged out. 