### PR TITLE
use version 0.1.5 of django-resumable-async-upload

### DIFF
--- a/TEKDB/requirements.txt
+++ b/TEKDB/requirements.txt
@@ -19,7 +19,7 @@ psutil
 redis
 django-filebrowser-no-grappelli>=4.0.0,<5.0.0
 XlsxWriter
-django-resumable-async-upload
+django-resumable-async-upload==0.1.5
 #-e git+https://github.com/dominno/django-moderation.git@master#egg=moderation
 
 #DEPENDENCIES


### PR DESCRIPTION
[asana task](https://app.asana.com/1/5541737610303/project/1199679790289799/task/1215181711122789?focus=true)

accompanying PR for https://github.com/Ecotrust/django-resumable-async-upload/pull/3