### PR TITLE
Versions and docs

### DIFF
--- a/.github/workflows/create-and-publish-docker-images.yml
+++ b/.github/workflows/create-and-publish-docker-images.yml
@@ -3,14 +3,19 @@ name: Create and publish web and proxy Docker images
 
 # manually trigger while testing 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
   workflow_dispatch:
 
-# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and the tags on the web and proxy image.
 env:
   REGISTRY: ghcr.io
+  METADATA_TAGS: &metadata-tags |
+    type=sha
+    type=semver,pattern=v{{version}}
+    type=semver,pattern=v{{major}}.{{minor}}
+    type=semver,pattern=v{{major}}
+    type=raw,latest
 
 jobs:
   build-and-push-image:
@@ -36,11 +41,20 @@ jobs:
         run: |
           IMAGE_NAME=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
+      
+      - name: Extract metadata (tags, labels) for Docker Web Image
+        id: meta-web
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/web
+          tags: *metadata-tags
+            
+      - name: Extract metadata (tags, labels) for Docker Proxy Image
+        id: meta-proxy
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/proxy
+          tags: *metadata-tags
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
@@ -55,8 +69,8 @@ jobs:
           context: ./TEKDB
           file: ./TEKDB/Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/web:latest,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/web:${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-web.outputs.tags }}
+          labels: ${{ steps.meta-web.outputs.labels }}
           cache-from: type=gha,scope=ghcr-web
           cache-to: type=gha,mode=max,scope=ghcr-web
 
@@ -67,8 +81,8 @@ jobs:
           context: ./proxy
           file: ./proxy/Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/proxy:latest,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/proxy:${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-proxy.outputs.tags }}
+          labels: ${{ steps.meta-proxy.outputs.labels }}
           cache-from: type=gha,scope=ghcr-proxy
           cache-to: type=gha,mode=max,scope=ghcr-proxy
       

--- a/README.md
+++ b/README.md
@@ -1,8 +1,39 @@
-# TEKDB
+# TEKDB ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/paigewilliams/9ac2331c0af09d1f4fc3921a2c2cd142/raw/coverage-badge.json)
+
 Traditional Ecological Knowledge Ethnographic Database Application
 
 ## [Development Installation](https://github.com/Ecotrust/TEKDB/wiki/Development-Installation) 
 
 ## [Running Tests](https://github.com/Ecotrust/TEKDB/wiki/Running-tests)
 
-![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/paigewilliams/9ac2331c0af09d1f4fc3921a2c2cd142/raw/coverage-badge.json)
+## CI/CD 
+
+This project has a few Github actions that run to have continous integration / continuous deployment with our environments. Below is a diagram on the path to production:
+
+```mermaid
+flowchart TB
+    subgraph Develop
+        CHECKOUT[checkout develop branch] --> FEAT[Create feature Branch]
+        FEAT --> PR[Submit Pull Request against develop branch]
+        PR --> APPROVE{Approval}
+        APPROVE -->|Approved| DEVMERGE[Merge into develop branch]
+        APPROVE -->|Rejected| REJECTED[Address feedback]
+        REJECTED --> APPROVE
+    end
+
+    subgraph Staging
+        DEVMERGE --> GHSTAGE[Github Action deploys to staging.itkdb.org]
+        GHSTAGE --> QA[QA on staging environment]
+        QA --> QAPASS{Passes QA}
+        QAPASS -->|PASSES| PRVERSION[Create PR to update version in settings.py]
+        QAPASS -->|FAILS| FEAT
+        PRVERSION --> PRDEV[Merge into develop branch]
+    end
+
+    subgraph Production
+        PRDEV --> PRMAIN[PR for develop into main]
+        PRMAIN --> RELEASE[Publish a new Release]
+        RELEASE --> GHPROD[Github Action builds and publishes images to GHCR]
+        GHPROD --> PRODDEPLOY[Manually deploy to demo.itkdb.org]
+    end
+```

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Traditional Ecological Knowledge Ethnographic Database Application
 
 ## [Running Tests](https://github.com/Ecotrust/TEKDB/wiki/Running-tests)
 
-## CI/CD 
+## Development Cycle
 
-This project has a few Github actions that run to have continous integration / continuous deployment with our environments. Below is a diagram on the path to production:
+This project aims to follow a specific development cycle to ease collaboration and keep the different environments in sync. Below is a diagram on what the development lifecycle should look like: 
 
 ```mermaid
 flowchart TB
@@ -25,15 +25,26 @@ flowchart TB
         DEVMERGE --> GHSTAGE[Github Action deploys to staging.itkdb.org]
         GHSTAGE --> QA[QA on staging environment]
         QA --> QAPASS{Passes QA}
-        QAPASS -->|PASSES| PRVERSION[Create PR to update version in settings.py]
-        QAPASS -->|FAILS| FEAT
-        PRVERSION --> PRDEV[Merge into develop branch]
     end
 
     subgraph Production
+        QAPASS -->|PASSES| PRVERSION[Create feature branch and open PR to update version in settings.py]
+        QAPASS -->|FAILS| FEAT
+        PRVERSION --> PRDEV[Merge into develop branch]
         PRDEV --> PRMAIN[PR for develop into main]
-        PRMAIN --> RELEASE[Publish a new Release]
+        PRMAIN --> PRMERGEMAIN[Merge into main branch]
+        PRMERGEMAIN --> RELEASE[Publish a new Release]
         RELEASE --> GHPROD[Github Action builds and publishes images to GHCR]
         GHPROD --> PRODDEPLOY[Manually deploy to demo.itkdb.org]
+        PRODDEPLOY --> QAPROD[Test in production]
+        QAPROD --> QAPASSPROD{Passes QA}
+        QAPASSPROD --> |PASSES| SUCCESS[Success!]
+        QAPASSPROD --> |Fails| HOTFIX[Create a hotfix branch off of main]
+        HOTFIX --> PRHOTFIX[PR for hotfix into main]
+        PRHOTFIX --> APPROVEHOTFIX{Approval}
+        APPROVEHOTFIX --> |Approval| MERGEHOTFIX[Merge into main branch]
+        APPROVEHOTFIX --> |Rejected| REJECTEDHOTFIX[Address feedback]
+        REJECTEDHOTFIX --> APPROVEHOTFIX
+        MERGEHOTFIX --> RELEASE
     end
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Traditional Ecological Knowledge Ethnographic Database Application
 
 ## Development Cycle
 
-This project aims to follow a specific development cycle to ease collaboration and keep the different environments in sync. Below is a diagram on what the development lifecycle should look like: 
+This project aims to follow a specific development cycle to ease collaboration and keep the different environments in sync. Below is a diagram of what the development lifecycle should look like:
 
 ```mermaid
 flowchart TB
@@ -22,7 +22,7 @@ flowchart TB
     end
 
     subgraph Staging
-        DEVMERGE --> GHSTAGE[Github Action deploys to staging.itkdb.org]
+        DEVMERGE --> GHSTAGE[GitHub Action deploys to staging.itkdb.org]
         GHSTAGE --> QA[QA on staging environment]
         QA --> QAPASS{Passes QA}
     end
@@ -34,7 +34,7 @@ flowchart TB
         PRDEV --> PRMAIN[PR for develop into main]
         PRMAIN --> PRMERGEMAIN[Merge into main branch]
         PRMERGEMAIN --> RELEASE[Publish a new Release]
-        RELEASE --> GHPROD[Github Action builds and publishes images to GHCR]
+        RELEASE --> GHPROD[GitHub Action builds and publishes images to GHCR]
         GHPROD --> PRODDEPLOY[Manually deploy to demo.itkdb.org]
         PRODDEPLOY --> QAPROD[Test in production]
         QAPROD --> QAPASSPROD{Passes QA}


### PR DESCRIPTION
Changes the "Create and publish web and proxy Docker images" github action to be triggered on merging to `main` to being triggered on creating a new release. It also adds version tags to the web and proxy images. I learned about YAML anchors to use the same tags for the web and proxy images. 

I also added a mermaid chart on the development lifecycle to better document on how to contribute to this repo.